### PR TITLE
fix: Return cmd.Help() Error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ go.work.sum
 
 # Build outputs
 kidbase10
+
+# IDE Configurations
+.vscode

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,8 +44,7 @@ arbitrary data. This command line provides a reference implementation of the
 protocol.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			cmd.Help()
-			return nil
+			return cmd.Help()
 		}
 		data := args[0]
 		if decode {


### PR DESCRIPTION
Return any error thrown by `cmd.Help()` in `root.go`. Caught by golangci-lint check.

Ignoring .vscode local settings directory, ensuring local IDE settings don't pollute the codebase.