### PR TITLE
feat: Verify Leading Whitespace

### DIFF
--- a/default_test.go
+++ b/default_test.go
@@ -1,34 +1,66 @@
 package main_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("default encoding", Label("e2e", "conformance"), func() {
+func runEncoder(ctx context.Context, toEncode string) (string, error) {
+	return ExecuteCommand(ctx, "./kidbase10", toEncode)
+}
+
+func runDecoder(ctx context.Context, toDecode string) (string, error) {
+	return ExecuteCommand(ctx, "./kidbase10", "--decode", toDecode)
+}
+
+var _ = Describe("default encoding", Label("e2e", "conformance", "encoding"), func() {
 
 	When("valid text is passed with no arguments", func() {
 
 		It("encodes text to an integer", func(ctx SpecContext) {
-			Expect(ExecuteCommand(ctx, "./kidbase10", "LANE")).To(Equal("51620000"))
+			Expect(runEncoder(ctx, "LANE")).To(Equal("51620000"))
 		})
 
-		It("pads text less than 8 characters in length", func() {
-			Skip("not implemented yet")
+		It("pads text less than 8 characters in length", func(ctx SpecContext) {
+			Expect(runEncoder(ctx, "I STARE")).To(Equal("40891720"))
 		})
 
-		It("splits text longer than 8 characters into lines of 8", func() {
-			Skip("not implented yet")
+		It("splits text longer than 8 characters into lines of 8", func(ctx SpecContext) {
+			expectedOutput := `40891720
+19093203
+45500000`
+			Expect(runEncoder(ctx, "I STARE AT THE HILL")).To(Equal(expectedOutput))
+		})
+
+		It("encodes leading whitespace as zeros", func(ctx SpecContext) {
+			Expect(runEncoder(ctx, "   LANE")).To(Equal("00051620"))
 		})
 	})
 })
 
-var _ = Describe("default decoding", Label("e2e", "conformance"), func() {
+var _ = Describe("default decoding", Label("e2e", "conformance", "decoding"), func() {
 
 	When("valid encoded text is passed with the decode flag", func() {
 
 		It("decodes an integer to text", func(ctx SpecContext) {
-			Expect(ExecuteCommand(ctx, "./kidbase10", "--decode", "51620000")).To(Equal("LANE"))
+			Expect(runDecoder(ctx, "51620000")).To(Equal("LANE"))
+		})
+
+		It("trims trailing whitespace", func(ctx SpecContext) {
+			Expect(runDecoder(ctx, "40891720")).To(Equal("I STARE"))
+		})
+
+		It("decodes multiline text", func(ctx SpecContext) {
+			encodedInput := `40891720
+19093203
+45500000`
+			Expect(runDecoder(ctx, encodedInput)).To(Equal("I STARE AT THE HILL"))
+		})
+
+		It("decodes leading zeros as whitespace", func(ctx SpecContext) {
+			Expect(runDecoder(ctx, "00051620")).To(Equal("   LANE"))
 		})
 	})
 })

--- a/encoding/decoder_test.go
+++ b/encoding/decoder_test.go
@@ -29,6 +29,7 @@ var _ = Describe("Decoder", Label("unit"), func() {
 			Entry("decodes with trailing zeros", "51620000", "LANE"),
 			Entry("decodes < 8 characters", "40891720", "I STARE"),
 			Entry("decodes 8 characters", "10891727", "A STARER"),
+			Entry("decodes leading whitespace", "00051620", "   LANE"),
 			Entry("decodes multi-line strings", `40891720
 19093203
 45500000`, "I STARE AT THE HILL"),

--- a/encoding/encoder_test.go
+++ b/encoding/encoder_test.go
@@ -29,6 +29,7 @@ var _ = Describe("Encoder", Label("unit"), func() {
 			Entry("encodes 4-char string", "LANE", "51620000"),
 			Entry("encodes < 8 characters", "I STARE", "40891720"),
 			Entry("encodes 8 characters", "A STARER", "10891727"),
+			Entry("encodes leading whitespace", "   LANE", "00051620"),
 			Entry("encodes > 8 characters", "I STARE AT THE HILL", `40891720
 19093203
 45500000`),


### PR DESCRIPTION
Add tests to verify leading whitespace is encoded as "0", and leading "0"s are decoded as whitespace.